### PR TITLE
Fix includes: std::map was used without #include <map>

### DIFF
--- a/common/src/utils/xcf.h
+++ b/common/src/utils/xcf.h
@@ -30,6 +30,7 @@
 #include <regex>
 #include <chrono>
 #include <iomanip>
+#include <map>
 
 
 //INCLUDE HTS LIBRARY

--- a/makefile
+++ b/makefile
@@ -26,6 +26,7 @@ VPATH=$(shell for file in `find src -name *.cpp`; do echo $$(dirname $$file); do
 
 NAME=$(shell basename $(CURDIR))
 BFILE=bin/$(NAME)
+MACFILE=bin/$(NAME)_mac
 EXEFILE=bin/$(NAME)_static
 
 #CONDITIONAL PATH DEFINITON
@@ -119,9 +120,25 @@ static_exe_robin_desktop: BOOST_LIB_IO=$(HTSSRC)/boost/lib/libboost_iostreams.a
 static_exe_robin_desktop: BOOST_LIB_PO=$(HTSSRC)/boost/lib/libboost_program_options.a
 static_exe_robin_desktop: $(EXEFILE)
 
+mac_apple_silicon: CXXFLAG=-O3 -mcpu=apple-m1 -D__COMMIT_ID__=\"$(COMMIT_VERS)\" -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
+mac_apple_silicon: LDFLAG=-O3
+mac_apple_silicon: HTSLIB_LIB=-lhts
+mac_apple_silicon: BOOST_LIB_IO=-lboost_iostreams
+mac_apple_silicon: BOOST_LIB_PO=-lboost_program_options
+mac_apple_silicon: $(MACFILE)
+
+mac_apple_silicon_static: CXXFLAG=-O3 -mcpu=apple-m1 -D__COMMIT_ID__=\"$(COMMIT_VERS)\" -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
+mac_apple_silicon_static: LDFLAG=-O3
+mac_apple_silicon_static: HTSLIB_LIB=/opt/homebrew/opt/htslib/lib/libhts.a
+mac_apple_silicon_static: BOOST_LIB_IO=/opt/homebrew/opt/boost/lib/libboost_iostreams.a
+mac_apple_silicon_static: BOOST_LIB_PO=/opt/homebrew/opt/boost/lib/libboost_program_options.a
+mac_apple_silicon_static: $(MACFILE)
 
 #COMPILATION RULES
 all: desktop
+
+$(MACFILE): $(OFILE)
+	$(CXX) $(LDFLAG) $^ $(HTSLIB_LIB) $(BOOST_LIB_IO) $(BOOST_LIB_PO) -o $@ $(DYN_LIBS)
 
 $(BFILE): $(OFILE)
 	$(CXX) $(LDFLAG) $^ $(HTSLIB_LIB) $(BOOST_LIB_IO) $(BOOST_LIB_PO) -o $@ $(DYN_LIBS)


### PR DESCRIPTION
`xcf.h` was using `std::map` without including it. This was only ever working because of transitive includes or order of includes. 

This fix is required to allow shapeit5 to build with Clang, I had made the change locally while working on https://github.com/odelaneau/shapeit5/pull/68 and then when trying to package shapeit5 on brew ran back into this missing #include.

I've seen missing includes like this cause breakage when updating to newer compilers too. libstdc++ has been working to reduce transitive includes.