### PR TITLE
Add a docker target for dynamic libs build with shapeit5

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,7 +29,13 @@ BFILE=bin/$(NAME)
 MACFILE=bin/$(NAME)_mac
 EXEFILE=bin/$(NAME)_static
 
-#CONDITIONAL PATH DEFINITON
+#CONDITIONAL PATH DEFINITONS
+docker: EXEFILE=bin/$(NAME)
+docker: DYN_LIBS=-lz -lpthread -lbz2 -llzma \
+	-lboost_iostreams -lboost_program_options -lboost_serialization \
+	-lcurl -lgcrypt -lhts
+docker: $(BFILE)
+
 system: DYN_LIBS=-lz -lpthread -lbz2 -llzma
 system: HTSSRC=/usr/local
 system: HTSLIB_INC=$(HTSSRC)/include/htslib


### PR DESCRIPTION
This is an innocuous change to the make file that creates a target for a native docker build of shapeit5.

This PR is for main/HEAD, so that subsequent versions of shapeit5 will work.

An additional PR to the current submodule commit associated with shapeit5, branched at [xcftools] subproject commit 48abb983455f8cc691711b597b1b45e4cefe6cf6 will be submitted with the proposed shapeit5 native docker build PR.