### PR TITLE
common: utils: Redirect XCF errors and warnings to log

### DIFF
--- a/common/src/utils/xcf.h
+++ b/common/src/utils/xcf.h
@@ -115,12 +115,11 @@ namespace helper_tools
 	}
 
 	inline void error(std::string s) {
-		std::cout << std::endl << "\x1B[31m" << "ERROR: " <<  "\033[0m" << s << std::endl;
-		exit(EXIT_FAILURE);
+		vrb.error(s);
 	}
 
 	inline void warning(std::string s) {
-		std::cout << std::endl << "\x1B[33m" << "WARNING: " <<  "\033[0m" << s << std::endl;
+		vrb.warning(s);
 	}
 
 	inline std::string date() {


### PR DESCRIPTION
XCF errors and warnings were only printed on stdout, redirect them through the logging and verbosity system. This allows the errors and warnings to be saved in the logs (--log).