### PR TITLE
fix: Mac build

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,8 +7,8 @@ dummy_build_folder_bin := $(shell mkdir -p bin)
 dummy_build_folder_obj := $(shell mkdir -p obj)
 
 #COMPILER & LINKER FLAGS
-CXXFLAGS+= -O3 -flto
-LDFLAGS+= -O3 -flto
+CXXFLAGS+= -O3
+LDFLAGS+= -O3
 
 # Test if on x86 and target Haswell & newer.
 # Disable this if building on x86 CPUs without AVX2 support.

--- a/makefile
+++ b/makefile
@@ -134,7 +134,7 @@ mac_apple_silicon_static: $(MACFILE)
 all: desktop
 
 $(MACFILE): $(OFILE)
-	$(CXX) $(LDFLAG) $^ $(HTSLIB_LIB) $(BOOST_LIB_IO) $(BOOST_LIB_PO) -o $@ $(DYN_LIBS)
+	$(CXX) $(LDFLAG) $^ $(HTSLIB_LIB) $(BOOST_LIB_IO) $(BOOST_LIB_PO) -o $@
 
 $(BFILE): $(OFILE)
 	$(CXX) $(LDFLAG) $^ -o $@ $(DYN_LIBS)

--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ endif
 # DYNAMIC LIBRARIES # Standard libraries are still dynamic in static exe
 DYN_LIBS_FOR_STATIC=-lz -lpthread -lbz2 -llzma -lcrypto -ldeflate -lcurl
 # Non static exe links with all libraries
-DYN_LIBS= -lboost_iostreams -lboost_program_options -lhts -lpthread
+DYN_LIBS= -lboost_iostreams -lboost_program_options -lhts -pthread
 
 HFILE=$(shell find src -name *.h)
 CFILE=$(shell find src -name *.cpp)

--- a/makefile
+++ b/makefile
@@ -7,17 +7,21 @@ dummy_build_folder_bin := $(shell mkdir -p bin)
 dummy_build_folder_obj := $(shell mkdir -p obj)
 
 #COMPILER & LINKER FLAGS
-CXXFLAG=-O3
-LDFLAG=-O3
+CXXFLAGS+= -O3 -flto
+LDFLAGS+= -O3 -flto
 
-#CXXFLAG=-O0 -g -Wno-ignored-attributes
-#LDFLAG=-O0
+# Test if on x86 and target Haswell & newer.
+# Disable this if building on x86 CPUs without AVX2 support.
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+    CXXFLAGS+= -march=x86-64-v3
+endif
 
 #COMMIT TRACING
 COMMIT_VERS=$(shell git rev-parse --short HEAD)
 COMMIT_DATE=$(shell git log -1 --format=%cd --date=short)
-CXXFLAG+= -D__COMMIT_ID__=\"$(COMMIT_VERS)\"
-CXXFLAG+= -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
+CXXFLAGS+= -D__COMMIT_ID__=\"$(COMMIT_VERS)\"
+CXXFLAGS+= -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
 
 # RMATH Support [YES/NO]
 ifeq ($(RMATH_SUPPORT),)
@@ -27,13 +31,13 @@ ifeq ($(RMATH_SUPPORT),YES)
 	RMATH_INC=/usr/share/R/include/
 	RMATH_LIB=/usr/lib/libRmath.a
 #	DYN_LIBS+= -lzstd -lhts
-	CXXFLAG+= -D__RMATH_LIB__ -I$(RMATH_INC)
+	CXXFLAGS+= -D__RMATH_LIB__ -I$(RMATH_INC)
 endif
 
 # DYNAMIC LIBRARIES # Standard libraries are still dynamic in static exe
 DYN_LIBS_FOR_STATIC=-lz -lpthread -lbz2 -llzma -lcrypto -ldeflate -lcurl
 # Non static exe links with all libraries
-DYN_LIBS=$(DYN_LIBS_FOR_STATIC) -lboost_iostreams -lboost_program_options -lhts
+DYN_LIBS= -lboost_iostreams -lboost_program_options -lhts -lpthread
 
 HFILE=$(shell find src -name *.h)
 CFILE=$(shell find src -name *.cpp)
@@ -101,13 +105,13 @@ olivier: BOOST_LIB_IO=/usr/lib/x86_64-linux-gnu/libboost_iostreams.a
 olivier: BOOST_LIB_PO=/usr/lib/x86_64-linux-gnu/libboost_program_options.a
 olivier: $(BFILE)
 
-static_exe: CXXFLAG=-O3 -mavx2 -mfma -D__COMMIT_ID__=\"$(COMMIT_VERS)\" -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
-static_exe: LDFLAG=-O3
+static_exe: CXXFLAGS=-O3 -mavx2 -mfma -D__COMMIT_ID__=\"$(COMMIT_VERS)\" -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
+static_exe: LDFLAGS=-O3
 static_exe: $(EXEFILE)
 
 # static desktop Robin
-static_exe_robin_desktop: CXXFLAG=-O2 -mavx2 -mfma -D__COMMIT_ID__=\"$(COMMIT_VERS)\" -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
-static_exe_robin_desktop: LDFLAG=-O2
+static_exe_robin_desktop: CXXFLAGS=-O2 -mavx2 -mfma -D__COMMIT_ID__=\"$(COMMIT_VERS)\" -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
+static_exe_robin_desktop: LDFLAGS=-O2
 static_exe_robin_desktop: HTSSRC=/home/robin/Dropbox/LIB
 static_exe_robin_desktop: HTSLIB_INC=$(HTSSRC)/htslib_minimal
 static_exe_robin_desktop: HTSLIB_LIB=$(HTSSRC)/htslib_minimal/libhts.a
@@ -116,34 +120,17 @@ static_exe_robin_desktop: BOOST_LIB_IO=$(HTSSRC)/boost/lib/libboost_iostreams.a
 static_exe_robin_desktop: BOOST_LIB_PO=$(HTSSRC)/boost/lib/libboost_program_options.a
 static_exe_robin_desktop: $(EXEFILE)
 
-mac_apple_silicon: CXXFLAG=-O3 -mcpu=apple-m1 -D__COMMIT_ID__=\"$(COMMIT_VERS)\" -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
-mac_apple_silicon: LDFLAG=-O3
-mac_apple_silicon: HTSLIB_LIB=-lhts
-mac_apple_silicon: BOOST_LIB_IO=-lboost_iostreams
-mac_apple_silicon: BOOST_LIB_PO=-lboost_program_options
-mac_apple_silicon: $(MACFILE)
-
-mac_apple_silicon_static: CXXFLAG=-O3 -mcpu=apple-m1 -D__COMMIT_ID__=\"$(COMMIT_VERS)\" -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
-mac_apple_silicon_static: LDFLAG=-O3
-mac_apple_silicon_static: HTSLIB_LIB=/opt/homebrew/opt/htslib/lib/libhts.a
-mac_apple_silicon_static: BOOST_LIB_IO=/opt/homebrew/opt/boost/lib/libboost_iostreams.a
-mac_apple_silicon_static: BOOST_LIB_PO=/opt/homebrew/opt/boost/lib/libboost_program_options.a
-mac_apple_silicon_static: $(MACFILE)
-
 #COMPILATION RULES
 all: desktop
 
-$(MACFILE): $(OFILE)
-	$(CXX) $(LDFLAG) $^ $(HTSLIB_LIB) $(BOOST_LIB_IO) $(BOOST_LIB_PO) -o $@
-
 $(BFILE): $(OFILE)
-	$(CXX) $(LDFLAG) $^ -o $@ $(DYN_LIBS)
+	$(CXX) $(LDFLAGS) $^ -o $@ $(DYN_LIBS)
 
 $(EXEFILE): $(OFILE)
-	$(CXX) $(LDFLAG) -static -static-libgcc -static-libstdc++ -pthread -o $(EXEFILE) $^ $(HTSLIB_LIB) $(BOOST_LIB_IO) $(BOOST_LIB_PO) -Wl,-Bstatic $(DYN_LIBS_FOR_STATIC)
+	$(CXX) $(LDFLAGS) -static -static-libgcc -static-libstdc++ -pthread -o $(EXEFILE) $^ $(HTSLIB_LIB) $(BOOST_LIB_IO) $(BOOST_LIB_PO) -Wl,-Bstatic $(DYN_LIBS_FOR_STATIC)
 
 obj/%.o: %.cpp $(HFILE)
-	$(CXX) $(CXXFLAG) -c $< -o $@ -Isrc -I$(HTSLIB_INC) -I$(BOOST_INC)
+	$(CXX) $(CXXFLAGS) -c $< -o $@ -Isrc -I$(HTSLIB_INC) -I$(BOOST_INC)
 
 clean: 
 	rm -f obj/*.o $(BFILE) $(EXEFILE)


### PR DESCRIPTION
Fix mac build: Do not need to explicitly link to ldeflate or any of the other dyn libs.

I was updating the PR for mac compatabillity for shapeit5 and noticed that latest xcftools is broken on mac.

https://github.com/odelaneau/shapeit5/pull/68/files